### PR TITLE
Update nm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ grabbing will happen. As such, it should work fine in almost all setups.
 To use it, you will need:
  * openh264 or x264
  * For audio supporting using AAC one of fdkaacenc, faac or avenc_aac
- * NetworkManager P2P patches
-   https://gitlab.freedesktop.org/NetworkManager/NetworkManager/merge_requests/24
+ * NetworkManager version > 1.15.2
 
 Issues
 ======


### PR DESCRIPTION
Initial support for wifi p2p is merged into nm. So we can update dependency to show nm master can be used (or future 1.15.3 tag)