### PR TITLE
Move Appdata file to /usr/share/metainfo

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -21,7 +21,7 @@ appstream_file = i18n.merge_file(
   output: 'org.gnome.NetworkDisplays.appdata.xml',
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
According to the Appstream specifications, Appdata files must now be installed in /usr/share/metainfo. /usr/share/appdata is a legacy path.

See: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html
and: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html