### PR TITLE
Avoid meson bug

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('gnome-network-displays', 'c',
   version: '0.90.1',
-  meson_version: '>= 0.42.0',
+  meson_version: '>= 0.46.1',
 )
 
 gnome = import('gnome')


### PR DESCRIPTION
Ask to use meson build system 0.46.1 and later.
Meson version 0.45.1 and 0.46.0 has a bug to fail compile.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>